### PR TITLE
Add Text Domain in plugin header

### DIFF
--- a/accelerated-moblie-pages.php
+++ b/accelerated-moblie-pages.php
@@ -8,6 +8,7 @@ Author: Ahmed Kaludi, Mohammed Kaludi
 Author URI: https://ampforwp.com/
 Donate link: https://www.paypal.me/Kaludi/25
 License: GPL2+
+Text Domain: accelerated-mobile-pages
 */
 
 // Exit if accessed directly.


### PR DESCRIPTION
Fixes error raised on translate.wordpress.org platform. Currently translate.wordpress.org page shows error: "This plugin is not properly prepared for localization" Error logs: https://wordpress.slack.com/archives/C0E7F4RND/p1493388504148703 and https://wordpress.slack.com/archives/C0E7F4RND/p1493388513152300

screenshots of warnings:
![image](https://user-images.githubusercontent.com/1820367/33522873-02f635fa-d833-11e7-987a-24add71397d0.png)
Note: this also mean that translators are not able to translate the plugin through wordpress.translate.org if they want to.

![image](https://user-images.githubusercontent.com/1820367/33522890-2c130f12-d833-11e7-9831-37c7837ec36b.png)
